### PR TITLE
NEW Add extension to update page request, add Subsites compatibility extension

### DIFF
--- a/_config/compat.yml
+++ b/_config/compat.yml
@@ -1,0 +1,8 @@
+---
+Name: sharedraftcontentcompatibility
+Only:
+  moduleexists: subsites
+---
+ShareDraftController:
+  extensions:
+    - ShareDraftSubsiteExtension

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -14,4 +14,3 @@ Controller:
 Director:
   rules:
     'preview': 'ShareDraftController'
----

--- a/code/controllers/ShareDraftController.php
+++ b/code/controllers/ShareDraftController.php
@@ -74,7 +74,11 @@ class ShareDraftController extends Controller
                 $_FILES = array(array());
 
                 // Create mock request; Simplify request to single top level request
-                $pageRequest = new SS_HTTPRequest('GET', $page->URLSegment);
+                $pageRequest = Injector::inst()->create('SS_HTTPRequest', 'GET', $page->URLSegment);
+
+                // Extend to allow other modules to modify the request before it's processed
+                $this->extend('updatePageRequest', $pageRequest, $page);
+
                 $pageRequest->match('$URLSegment//$Action/$ID/$OtherID', true);
                 $rendered = $controller->handleRequest($pageRequest, $this->model);
 

--- a/code/extensions/ShareDraftSubsiteExtension.php
+++ b/code/extensions/ShareDraftSubsiteExtension.php
@@ -1,0 +1,21 @@
+<?php
+
+class ShareDraftSubsiteExtension extends Extension
+{
+    /**
+     * If the page has a subsite ID, add it to the URL. This ensures that subsite specific data is honoured
+     * when generating previews. See {@link Subsite::currentSubsiteID()}.
+     *
+     * @param SS_HTTPRequest $request
+     * @param SiteTree $page
+     */
+    public function updatePageRequest(SS_HTTPRequest $request, SiteTree $page)
+    {
+        if (!$page->SubsiteID) {
+            return;
+        }
+
+        // @todo don't modify superglobals directly, once Subsite::currentSubsiteID() stops doing it
+        $_GET['SubsiteID'] = (int) $page->SubsiteID;
+    }
+}


### PR DESCRIPTION
This adds a subsite extension if subsites is installed and the page that's being previews has a Subsite ID, and inserts that ID into the `$_GET` superglobal as per `Subsite::currentSubsiteID`.

Fixes #63 
