### PR TITLE
 FIX Vendorise module, add autoloader, remove constant from _config.php

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,37 @@
 language: php
 
-php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
+dist: trusty
 
 env:
-  - DB=MYSQL CORE_RELEASE=4
+  global:
+    - COMPOSER_ROOT_VERSION=2.x-dev
 
 matrix:
   include:
     - php: 5.6
-      env: DB=PGSQL CORE_RELEASE=4
+      env: DB=MYSQL PHPCS_TEST=1 PHPUNIT_TEST=1
+    - php: 7.0
+      env: DB=PGSQL PHPUNIT_TEST=1
+    - php: 7.0
+      env: DB=MYSQL PHPUNIT_TEST=1
+    - php: 7.1
+      env: DB=MYSQL PHPUNIT_COVERAGE_TEST=1
 
 before_script:
-  - composer self-update || true
-  - git clone git://github.com/silverstripe/silverstripe-travis-support.git ~/travis-support
-  - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss
-  - cd ~/builds/ss
+  # Init PHP
+  - phpenv rehash
+  - phpenv config-rm xdebug.ini
+
+  # Install composer dependencies
+  - composer validate
+  - composer require silverstripe/installer 4.0.x-dev  --no-update
+  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.0.x-dev --no-update; fi
+  - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 script:
-  - vendor/bin/phpunit sharedraftcontent/tests/
+  - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit; fi
+  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=coverage.xml; fi
+  - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs --standard=vendor/silverstripe/framework/phpcs.xml.dist src/ tests/ ; fi
+
+after_success:
+  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml; fi

--- a/_config.php
+++ b/_config.php
@@ -1,3 +1,1 @@
 <?php
-
-define('SHAREDRAFTCONTENT_DIR', basename(__DIR__));

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "silverstripe/sharedraftcontent",
-    "type": "silverstripe-module",
+    "type": "silverstripe-vendormodule",
     "description": "Share draft page content with non-CMS users",
     "license": "BSD-3-Clause",
     "keywords": ["silverstripe"],
@@ -23,13 +23,22 @@
         "silverstripe/cms": "^4.0@dev"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8"
+        "phpunit/phpunit": "^5.7",
+        "squizlabs/php_codesniffer": "^3.0"
     },
-    "extra":
-    {
-        "branch-alias":
-        {
+    "extra": {
+        "branch-alias": {
             "dev-master": "2.x-dev"
+        },
+        "expose": [
+            "css",
+            "javascript"
+        ]
+    },
+    "autoload": {
+        "psr-4": {
+            "SilverStripe\\ShareDraftContent\\": "src/",
+            "SilverStripe\\ShareDraftContent\\Tests\\": "tests/"
         }
     },
     "minimum-stability": "dev",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<phpunit bootstrap="vendor/silverstripe/cms/tests/bootstrap.php" colors="true">
+    <testsuite name="Default">
+        <directory>tests</directory>
+    </testsuite>
+
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src/</directory>
+            <exclude>
+                <directory suffix=".php">tests/</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Controllers/ShareDraftController.php
+++ b/src/Controllers/ShareDraftController.php
@@ -69,7 +69,7 @@ class ShareDraftController extends Controller
         $controller = $this->getControllerFor($page);
 
         if (!$shareToken->isExpired() && $page->generateKey($shareToken->Token) === $key) {
-            Requirements::css(SHAREDRAFTCONTENT_DIR . '/css/top-bar.css');
+            Requirements::css('silverstripe/sharedraftcontent:css/top-bar.css');
 
             // Temporarily un-secure the draft site and switch to draft
             $oldSecured = Session::get('unsecuredDraftSite');
@@ -115,7 +115,7 @@ class ShareDraftController extends Controller
      */
     protected function errorPage()
     {
-        Requirements::css(SHAREDRAFTCONTENT_DIR . '/css/error-page.css');
+        Requirements::css('silverstripe/sharedraftcontent:css/error-page.css');
 
         return $this->renderWith('ShareDraftContentError');
     }

--- a/src/Extensions/ShareDraftContentRequirementsExtension.php
+++ b/src/Extensions/ShareDraftContentRequirementsExtension.php
@@ -7,14 +7,9 @@ use SilverStripe\View\Requirements;
 
 class ShareDraftContentRequirementsExtension extends DataExtension
 {
-    /**
-     * @todo Once CMSMain::init is protected, update visibility
-     *
-     * {@inheritDoc}
-     */
     public function init()
     {
-        Requirements::css(SHAREDRAFTCONTENT_DIR . '/css/share-component.css');
-        Requirements::javascript(SHAREDRAFTCONTENT_DIR . '/javascript/main.js');
+        Requirements::css('silverstripe/sharedraftcontent:css/share-component.css');
+        Requirements::javascript('silverstripe/sharedraftcontent:javascript/main.js');
     }
 }

--- a/src/Models/ShareToken.php
+++ b/src/Models/ShareToken.php
@@ -45,7 +45,7 @@ class ShareToken extends DataObject
 
         $validForSeconds = (int) $this->ValidForDays * 24 * 60 * 60;
 
-        $nowSeconds = strtotime(DBDatetime::now()->Format("Y-m-d H:i:s"));
+        $nowSeconds = DBDatetime::now()->getTimestamp();
 
         return ($createdSeconds + $validForSeconds) <= $nowSeconds;
     }


### PR DESCRIPTION
This sets the new Travis CI setup state, and converts the module to a vendor module. Also removes the \_config.php constant, using the new requirements API instead. I've updated the timestamp in ShareToken to not rely on PHP date formats, since DBDatetime doesn't use them any more.

There's a failing test still, but that's fixed in #67 