### PR TITLE
FIX added session constructor arguments to object creation

### DIFF
--- a/src/Controllers/ShareDraftController.php
+++ b/src/Controllers/ShareDraftController.php
@@ -54,7 +54,9 @@ class ShareDraftController extends Controller
             $session = $this->getRequest()->getSession();
         } catch (BadMethodCallException $e) {
             // Create a new session
-            $session = $this->getRequest()->setSession(Injector::inst()->create(Session::class));
+            $session = $this->getRequest()
+                ->setSession(Injector::inst()->create(Session::class, []))
+                ->getSession();
         }
         /**
          * @var ShareToken $shareToken


### PR DESCRIPTION
Fixes the broken test on master caused by missing Session::__construct argument.