### PR TITLE
FIX Handle edge case where controller does not have a url_segment defined

### DIFF
--- a/src/Extensions/ShareDraftContentControllerExtension.php
+++ b/src/Extensions/ShareDraftContentControllerExtension.php
@@ -3,7 +3,6 @@
 namespace SilverStripe\ShareDraftContent\Extensions;
 
 use SilverStripe\Core\Extension;
-use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
 
 class ShareDraftContentControllerExtension extends Extension
@@ -20,7 +19,7 @@ class ShareDraftContentControllerExtension extends Extension
      */
     public function MakeShareDraftLink()
     {
-        if ($member = Member::currentUser()) {
+        if ($member = Security::getCurrentUser()) {
             if ($this->owner->hasMethod('CurrentPage') && $this->owner->CurrentPage()->canEdit($member)) {
                 return $this->owner->CurrentPage()->ShareTokenLink();
             } elseif ($this->owner->hasMethod('canEdit') && $this->owner->canEdit($member)) {
@@ -36,6 +35,9 @@ class ShareDraftContentControllerExtension extends Extension
      */
     public function getShareDraftLinkAction()
     {
-        return $this->owner->Link('MakeShareDraftLink');
+        if ($this->owner->config()->get('url_segment')) {
+            return $this->owner->Link('MakeShareDraftLink');
+        }
+        return '';
     }
 }


### PR DESCRIPTION
Because the share draft content controller extension is applied to the base Controller class (which doesn't have a url_segment), this can throw errors in other modules particularly when running unit tests.

We can check that it has a url_segment (happy path) to avoid this.

Also replace deprecated code.