### PR TITLE
Disable HTTP caches on preview links

### DIFF
--- a/code/controllers/ShareDraftController.php
+++ b/code/controllers/ShareDraftController.php
@@ -32,6 +32,9 @@ class ShareDraftController extends Controller
      */
     public function preview(SS_HTTPRequest $request)
     {
+        // Ensure this URL doesn't get picked up by HTTP caches
+        HTTPCacheControl::singleton()->disableCache();
+
         $key = $request->param('Key');
         $token = $request->param('Token');
 


### PR DESCRIPTION
Using new core API, see https://github.com/silverstripe/silverstripe-framework/pull/8086

Note that this release line already requires SilverStripe 3.7 or higher