### PR TITLE
FIX Generating a share draft link now only requires canView() permissions rather than canEdit()

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ This module adds a 'Share draft' action menu to the CMS. This enables Content Au
 
 ## Requirements
 
-- SilverStripe ^4.2
+- SilverStripe ^4.3
 
 Note: this version is compatible with SilverStripe 4. For SilverStripe 3, please see the 1.x release line.
 

--- a/src/Extensions/ShareDraftContentControllerExtension.php
+++ b/src/Extensions/ShareDraftContentControllerExtension.php
@@ -10,9 +10,9 @@ class ShareDraftContentControllerExtension extends Extension
     /**
      * @var array
      */
-    private static $allowed_actions = array(
+    private static $allowed_actions = [
         'MakeShareDraftLink',
-    );
+    ];
 
     /**
      * @return mixed
@@ -20,9 +20,10 @@ class ShareDraftContentControllerExtension extends Extension
     public function MakeShareDraftLink()
     {
         if ($member = Security::getCurrentUser()) {
-            if ($this->owner->hasMethod('CurrentPage') && $this->owner->CurrentPage()->canEdit($member)) {
+            if ($this->owner->hasMethod('CurrentPage') && $this->owner->CurrentPage()->canView($member)) {
                 return $this->owner->CurrentPage()->ShareTokenLink();
-            } elseif ($this->owner->hasMethod('canEdit') && $this->owner->canEdit($member)) {
+            }
+            if ($this->owner->hasMethod('canView') && $this->owner->canView($member)) {
                 return $this->owner->ShareTokenLink();
             }
         }


### PR DESCRIPTION
If you are a content editor and viewing a page which you can't edit, for example mid-way through a workflow transition, you should still be able to generate a link to share the draft content with others. Your ability to view the content at this point is enough to allow you to share it with others, you shouldn't need to be able to edit the page.

Fixes https://github.com/silverstripe/silverstripe-sharedraftcontent/issues/94 and closes https://github.com/symbiote/silverstripe-advancedworkflow/pull/387