### PR TITLE
fix: ensure preview url displays the correct subsite url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ before_script:
   # Extra $PATH
   - export PATH=/usr/lib/chromium-browser/:$PATH
 
+  # Travis build
+  - echo 'memory_limit=-1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+
   # Init PHP
   - phpenv rehash
   - phpenv config-rm xdebug.ini

--- a/src/Extensions/ShareDraftContentSiteTreeExtension.php
+++ b/src/Extensions/ShareDraftContentSiteTreeExtension.php
@@ -55,8 +55,14 @@ class ShareDraftContentSiteTreeExtension extends DataExtension
     {
         $shareToken = $this->getNewShareToken();
 
+        if ($this->owner->SubsiteID) {
+            $link = $this->owner->Subsite()->domain();
+        } else {
+            $link = Director::absoluteBaseURL();
+        }
+
         return Controller::join_links(
-            Director::absoluteBaseURL(),
+            $link,
             'preview',
             $this->generateKey($shareToken->Token),
             $shareToken->Token

--- a/src/Extensions/ShareDraftContentSiteTreeExtension.php
+++ b/src/Extensions/ShareDraftContentSiteTreeExtension.php
@@ -10,6 +10,7 @@ use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\HasManyList;
 use SilverStripe\Security\RandomGenerator;
 use SilverStripe\ShareDraftContent\Models\ShareToken;
+use SilverStripe\Subsites\Model\Subsite;
 
 /**
  * @property SiteTree|ShareDraftContentSiteTreeExtension $owner
@@ -55,7 +56,7 @@ class ShareDraftContentSiteTreeExtension extends DataExtension
     {
         $shareToken = $this->getNewShareToken();
 
-        if ($this->owner->SubsiteID) {
+        if (class_exists(Subsite::class) && $this->owner->SubsiteID) {
             $link = $this->owner->Subsite()->domain();
         } else {
             $link = Director::absoluteBaseURL();


### PR DESCRIPTION
Use the primary domain for sharing draft content from subsite, fallback to Director::absoluteBaseURL() for main site.

**Note**
This will need to be added to upstream 2.3 branch, have just fixed this at it's lowest point.